### PR TITLE
support material zOffset override

### DIFF
--- a/src/types/materials.ts
+++ b/src/types/materials.ts
@@ -17,6 +17,7 @@ export interface MaterialStyleValues {
   bridgingFanSpeed: NumericStyleVariant<'%'> | AutoStyleVariant;
   towerSpeed: number;
   maxBridgingSpeed: number;
+  zOffset: number;
 }
 
 export type MaterialStyleFlags = {


### PR DESCRIPTION
### Description
- Support `z-offset` for material overrides 
- If no material override is preset use the `z-override` from project
- If one or more materials have an override use the material with the highest `z-offset` override 
