### PR TITLE
support zOffset material override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaic-canvas/ps-profile-conversion",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "main": "dist/index.js",
   "author": "Mosaic Manufacturing Ltd.",
   "repository": {

--- a/src/types/materials.ts
+++ b/src/types/materials.ts
@@ -17,6 +17,7 @@ export interface MaterialStyleValues {
   bridgingFanSpeed: NumericStyleVariant<'%'> | AutoStyleVariant;
   towerSpeed: number;
   maxBridgingSpeed: number;
+  zOffset: number;
 }
 
 export type MaterialStyleFlags = {


### PR DESCRIPTION
### Description

- Support z-offset for material overrides
- If no material override is preset use the z-override from project
- If one or more materials have an override use the material with the highest z-offset override