### PR TITLE
Add support for element multi color 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaic-canvas/ps-profile-conversion",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "main": "dist/index.js",
   "author": "Mosaic Manufacturing Ltd.",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -682,7 +682,9 @@ const index = ({
     case 'daf':
       profile.useFirmwareRetraction = false;
       profile.filamentDiameter = new Array(extruderCount).fill(1.75);
+      profile.preSideTransitionPrinterscript = '';
       profile.sideTransitionPrinterscript = '';
+      profile.postSideTransitionPrinterscript = '';
       break;
     case 'makerbot':
       profile.useRelativeEDistances = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import type { Material } from './types/materials';
 import type { PaletteData } from './types/palette';
 import type { MachineSettings } from './types/printers';
 import { Firmware } from './types/printers';
-import type { StyleSettings } from './types/styles';
+import { type StyleSettings, TransitionMethod } from './types/styles';
 import type { TransitionTower, VariableTransitions } from './types/transitions';
 import {
   getMaterialFieldValue,
@@ -681,6 +681,8 @@ const index = ({
     case 'mcfx':
     case 'daf':
       profile.useFirmwareRetraction = false;
+      profile.filamentDiameter = new Array(extruderCount).fill(1.75);
+      profile.sideTransitionPrinterscript = '';
       break;
     case 'makerbot':
       profile.useRelativeEDistances = true;
@@ -753,7 +755,8 @@ const index = ({
     }
   }
 
-  if (style.transitionMethod === 2) {
+  // DAF printers are always considered as using side transitions
+  if (style.transitionMethod === TransitionMethod.Side || machine.extension === 'daf') {
     if (machine.preSideTransitionSequence) {
       if (machine.preSideTransitionSequence.startsWith('@printerscript')) {
         profile.preSideTransitionPrinterscript = machine.preSideTransitionSequence;


### PR DESCRIPTION
- if `daf` file e.g.: element
  - Overrides all `filamentDiameter` to `1.75`  
  - Always set `sideTransitionPrinterscript` to be empty 
  - Update the logic to ensure that DAF printers are always set to use side transitions