### PR TITLE
Bugfix / Force absolute extrusion for element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaic-canvas/ps-profile-conversion",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "dist/index.js",
   "author": "Mosaic Manufacturing Ltd.",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -914,12 +914,13 @@ const index = ({
   switch (machine.extension) {
     case 'mcfx':
     case 'daf':
-      profile.useFirmwareRetraction = false;
       profile.filamentDiameter = new Array(extruderCount).fill(1.75);
       profile.preSideTransitionPrinterscript = '';
       profile.sideTransitionPrinterscript = '';
       profile.postSideTransitionPrinterscript = '';
       profile.gcodeFlavor = GCodeFlavor.MARLIN_2;
+      profile.useRelativeEDistances = false;
+      profile.useFirmwareRetraction = false;
       break;
     case 'makerbot':
       profile.useRelativeEDistances = true;


### PR DESCRIPTION
- Ensure that `useRelativeEDistances` is always set to false for Element (.mcfx/.daf) printers
- Bump package version