### PR TITLE
Bugfix/ Organic Support default settings adjustments 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaic-canvas/ps-profile-conversion",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "dist/index.js",
   "author": "Mosaic Manufacturing Ltd.",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,12 @@ import {
   variantValue,
 } from './utils';
 
+// Scaling factor for support tree branch diameter
+const SUPPORT_TREE_BRANCH_DIAMETER_SCALING_FACTOR = 2.5;
+
+// Scaling factor for support tree tip diameter
+const SUPPORT_TREE_TIP_DIAMETER_SCALING_FACTOR = 2;
+
 const convertSolidFillStyle = (solidFillStyle: number): SolidFillPattern => {
   switch (solidFillStyle) {
     case 0: // rectilinear
@@ -544,6 +550,21 @@ const index = ({
   } else {
     profile.supportMaterialInterfaceExtruder = profile.supportMaterialExtruder;
     profile.supportMaterialInterfaceLayers = 0;
+  }
+
+  // organic support tree settings
+  // automatically scale parameters based on nozzle diameter to prevent constraint violations
+  if (profile.supportMaterialStyle == SupportStyle.ORGANIC) {
+    // support_tree_tip_diameter: must be ≥ support_material_extrusion_width
+    profile.supportTreeTipDiameter = Math.max(
+      profile.supportTreeTipDiameter,
+      SUPPORT_TREE_TIP_DIAMETER_SCALING_FACTOR * profile.supportMaterialExtrusionWidth
+    );
+    // support_tree_branch_diameter: Must be ≥ 2 × support_material_extrusion_width and ≥ support_tree_tip_diameter
+    profile.supportTreeBranchDiameter = Math.max(
+      profile.supportTreeBranchDiameter,
+      SUPPORT_TREE_BRANCH_DIAMETER_SCALING_FACTOR * profile.supportMaterialExtrusionWidth
+    );
   }
 
   // rafts

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,7 +563,7 @@ const index = ({
     // support_tree_branch_diameter: Must be ≥ 2 × support_material_extrusion_width and ≥ support_tree_tip_diameter
     profile.supportTreeBranchDiameter = Math.max(
       profile.supportTreeBranchDiameter,
-      SUPPORT_TREE_BRANCH_DIAMETER_SCALING_FACTOR * profile.supportMaterialExtrusionWidth
+      roundTo(SUPPORT_TREE_BRANCH_DIAMETER_SCALING_FACTOR * profile.supportMaterialExtrusionWidth, 1)
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,10 @@ import {
   variantValue,
 } from './utils';
 
-// Scaling factor for support tree branch diameter
+// scaling factor for support tree branch diameter
 const SUPPORT_TREE_BRANCH_DIAMETER_SCALING_FACTOR = 2.5;
 
-// Scaling factor for support tree tip diameter
+// scaling factor for support tree tip diameter
 const SUPPORT_TREE_TIP_DIAMETER_SCALING_FACTOR = 2;
 
 const convertSolidFillStyle = (solidFillStyle: number): SolidFillPattern => {
@@ -553,7 +553,7 @@ const index = ({
   }
 
   // organic support tree settings
-  // automatically scale parameters based on nozzle diameter to prevent constraint violations
+  // automatically scale parameters based on supportMaterialExtrusionWidth to prevent constraint violations
   if (profile.supportMaterialStyle == SupportStyle.ORGANIC) {
     // support_tree_tip_diameter: must be ≥ support_material_extrusion_width
     profile.supportTreeTipDiameter = Math.max(


### PR DESCRIPTION
Auto adjust organic support settings to avoid the following Prusaslicer errors: 
- `support_tree_tip_diameter` Must be ≥ `support_material_extrusion_width`	
  - update it to be `2 * support_material_extrusion_width`
- `support_tree_branch_diameter` Must be ≥ `2 × support_material_extrusion_width` and  ≥ `support_tree_tip_diameter`
  - update it to be `2 .5 * support_material_extrusion_width`
