### PR TITLE
Revert "Enhancement/emit motion params to gcode for time estimation"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaic-canvas/ps-profile-conversion",
-  "version": "0.3.8",
+  "version": "0.3.10",
   "main": "dist/index.js",
   "author": "Mosaic Manufacturing Ltd.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaic-canvas/ps-profile-conversion",
-  "version": "0.3.9",
+  "version": "0.3.8",
   "main": "dist/index.js",
   "author": "Mosaic Manufacturing Ltd.",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import {
   BrimType,
   GCodeFlavor,
   InfillPattern,
-  MachineLimitsUsage,
   SeamPosition,
   SolidFillPattern,
   SupportStyle,
@@ -948,14 +947,6 @@ const index = ({
       profile.gcodeFlavor = GCodeFlavor.MARLIN_2;
       profile.useRelativeEDistances = false;
       profile.useFirmwareRetraction = false;
-      // Emit default motion parameters (M201, M203, M204, and M205 G-code commands) specifically to ensure
-      // PrusaSlicer's time estimation uses our custom travel acceleration values instead of its default.
-      // Without emitting these parameters, PrusaSlicer ignores the travel acceleration values we provide
-      // and falls back to its own built-in default travel acceleration for time estimation calculations.
-      // Note: These parameters are added to the G-code header but removed during post-processing
-      // so that if the printer firmware is updated and we don't make corresponding parity changes,
-      // the printer's updated firmware values will take precedence.
-      profile.machineLimitsUsage = MachineLimitsUsage.EMIT_TO_GCODE;
       break;
     case 'makerbot':
       profile.useRelativeEDistances = true;


### PR DESCRIPTION
Reverts MosaicManufacturing/ps-profile-conversion#26
- Emitting to G-code also clamps the M204 commands
- Increase package version to not conflict with NPM releases 